### PR TITLE
Add test for subnets

### DIFF
--- a/tests/foreman/ui_airgun/test_subnet.py
+++ b/tests/foreman/ui_airgun/test_subnet.py
@@ -1,0 +1,15 @@
+from nailgun import entities
+
+
+def test_positive_create(session):
+    subnet = entities.Subnet()
+    subnet.create_missing()
+    name = subnet.name
+    with session:
+        session.subnet.create({
+            'name': name,
+            'network_address': subnet.network,
+            'network_mask': subnet.mask,
+            'boot_mode': 'Static',
+        })
+        assert session.subnet.search(name) == name


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_subnet.py 
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                             
2018-03-01 13:19:01 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_subnet.py .                                                                                                                                               [100%]

================================================================================= 1 passed in 43.69 seconds ============================================================================
```