### PR TITLE
add one more os test co cover parameter widget

### DIFF
--- a/tests/foreman/ui_airgun/test_os.py
+++ b/tests/foreman/ui_airgun/test_os.py
@@ -71,6 +71,25 @@ def test_positive_create_with_ptable_same_org(module_org, session):
         assert session.operatingsystem.search(name) == os_full_name
 
 
+def test_positive_create_with_params(session):
+    name = gen_string('alpha')
+    major_version = gen_string('numeric', 2)
+    param_name = gen_string('alpha')
+    param_value = gen_string('alpha')
+    with session:
+        session.operatingsystem.create({
+            'name': name,
+            'major': major_version,
+            'parameters': {'name': param_name, 'value': param_value},
+        })
+        os_full_name = '{} {}'.format(name, major_version)
+        assert session.operatingsystem.search(name) == os_full_name
+        values = session.operatingsystem.read(os_full_name)
+        assert len(values['parameters']) == 1
+        assert values['parameters'][0]['name'] == param_name
+        assert values['parameters'][0]['value'] == param_value
+
+
 def test_positive_delete(session):
     name = gen_string('alpha')
     major = gen_string('numeric', 2)


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_os.py
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 6 items                                                                                                                                                                            
2018-03-02 14:47:44 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_os.py ......                                                                                                                                              [100%]

================================================================================= 6 passed in 234.12 seconds ======================================================================
```