### PR TITLE
add ak entity test

### DIFF
--- a/tests/foreman/ui_airgun/test_activationkey.py
+++ b/tests/foreman/ui_airgun/test_activationkey.py
@@ -1,0 +1,13 @@
+from robottelo.datafactory import gen_string
+
+
+def test_positive_create(session):
+    ak_name = gen_string('alpha')
+    with session:
+        session.activationkey.create({
+            'name': ak_name,
+            'unlimited_hosts': False,
+            'max_hosts': 2,
+            'description': gen_string('alpha'),
+        })
+        assert session.activationkey.search(ak_name) == ak_name

--- a/tests/foreman/ui_airgun/test_os.py
+++ b/tests/foreman/ui_airgun/test_os.py
@@ -98,4 +98,4 @@ def test_positive_delete(session):
         assert session.operatingsystem.search(name) == '{} {}'.format(
             name, major)
         session.operatingsystem.delete(name)
-        assert session.operatingsystem.search(name) == None
+        assert session.operatingsystem.search(name) is None


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_os.py
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 6 items                                                                                                                                                                            
2018-03-05 14:01:00 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_os.py ......                                                                                                                                              [100%]

================================================================================= 6 passed in 247.20 seconds =================================================================================

py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_activationkey.py 
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                             
2018-03-05 14:08:21 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py .                                                                                                                                        [100%]

================================================================================= 1 passed in 47.18 seconds =======================================================================
```