### PR TITLE
Ported AK test_negative_usage_limit test

### DIFF
--- a/tests/foreman/ui_airgun/test_activationkey.py
+++ b/tests/foreman/ui_airgun/test_activationkey.py
@@ -21,8 +21,7 @@ def test_positive_create(session):
     with session:
         session.activationkey.create({
             'name': ak_name,
-            'unlimited_hosts': False,
-            'max_hosts': 2,
+            'hosts_limit': 2,
             'description': gen_string('alpha'),
         })
         assert session.activationkey.search(ak_name) == ak_name
@@ -139,16 +138,16 @@ def test_negative_usage_limit(session, module_org):
     :CaseLevel: System
     """
     name = gen_string('alpha')
-    host_limit = '1'
+    hosts_limit = '1'
     with session:
         session.activationkey.create({
             'name': name,
             'lce': {ENVIRONMENT: True},
         })
         assert session.activationkey.search(name) == name
-        session.activationkey.update(name, values={'host_limit': host_limit})
+        session.activationkey.update(name, values={'hosts_limit': hosts_limit})
         ak = session.activationkey.read(name)
-        assert ak['host_limit'] == host_limit
+        assert ak['hosts_limit'] == hosts_limit
     with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
         with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
             vm1.install_katello_ca()
@@ -160,6 +159,6 @@ def test_negative_usage_limit(session, module_org):
             assert len(result.stderr) > 0
             assert (
                 'Max Hosts ({0}) reached for activation key'
-                .format(host_limit)
+                .format(hosts_limit)
                 in result.stderr
             )

--- a/tests/foreman/ui_airgun/test_activationkey.py
+++ b/tests/foreman/ui_airgun/test_activationkey.py
@@ -5,10 +5,15 @@ from robottelo.api.utils import (
     cv_publish_promote,
     promote,
 )
-from robottelo.constants import DISTRO_RHEL6
+from robottelo.constants import DISTRO_RHEL6, ENVIRONMENT
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier3
+from robottelo.decorators import fixture, skip_if_not_set, tier3
 from robottelo.vm import VirtualMachine
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
 
 
 def test_positive_create(session):
@@ -74,6 +79,7 @@ def test_positive_edit(session):
         assert ak_values['description'] == description
 
 
+@skip_if_not_set('clients')
 @tier3
 def test_positive_delete_with_system(session):
     """Delete an Activation key which has registered systems
@@ -112,3 +118,48 @@ def test_positive_delete_with_system(session):
             assert vm.subscribed
             session.activationkey.delete(name)
             assert session.activationkey.search(name) is None
+
+
+@skip_if_not_set('clients')
+@tier3
+def test_negative_usage_limit(session, module_org):
+    """Test that Usage limit actually limits usage
+
+    :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
+
+    :Steps:
+        1. Create Activation key
+        2. Update Usage Limit to a finite number
+        3. Register Systems to match the Usage Limit
+        4. Attempt to register an other system after reaching the Usage
+            Limit
+
+    :expectedresults: System Registration fails. Appropriate error shown
+
+    :CaseLevel: System
+    """
+    name = gen_string('alpha')
+    host_limit = '1'
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {ENVIRONMENT: True},
+        })
+        assert session.activationkey.search(name) == name
+        session.activationkey.update(name, values={'host_limit': host_limit})
+        ak = session.activationkey.read(name)
+        assert ak['host_limit'] == host_limit
+    with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
+            vm1.install_katello_ca()
+            vm1.register_contenthost(module_org.label, name)
+            assert vm1.subscribed
+            vm2.install_katello_ca()
+            result = vm2.register_contenthost(module_org.label, name)
+            assert not vm2.subscribed
+            assert len(result.stderr) > 0
+            assert (
+                'Max Hosts ({0}) reached for activation key'
+                .format(host_limit)
+                in result.stderr
+            )


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k test_negative_usage_limit
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 6 items
2018-03-23 15:30:47 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit PASSED [100%]

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 312.34 seconds ===================
```