### PR TITLE
add cv+yum_repo test

### DIFF
--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -1,4 +1,7 @@
+from nailgun import entities
+
 from robottelo.datafactory import gen_string
+from robottelo.decorators import tier2
 
 
 def test_positive_create(session):
@@ -17,3 +20,29 @@ def test_positive_create(session):
         assert cv_values['Details']['label'] == label
         assert cv_values['Details']['description'] == description
         assert cv_values['Details']['composite'] == 'No'
+
+
+@tier2
+def test_positive_add_custom_content(session):
+    """Associate custom content in a view
+
+    :id: 7128fc8b-0e8c-4f00-8541-2ca2399650c8
+
+    :setup: Sync custom content
+
+    :expectedresults: Custom content can be seen in a view
+
+    :CaseLevel: Integration
+    """
+    org = entities.Organization().create()
+    cv_name = gen_string('alpha')
+    repo_name = gen_string('alpha')
+    product = entities.Product(organization=org).create()
+    entities.Repository(name=repo_name, product=product).create()
+    with session:
+        session.organization.select(org_name=org.name)
+        session.contentview.create({'name': cv_name})
+        assert session.contentview.search(cv_name) == cv_name
+        session.contentview.add_yum_repo(cv_name, repo_name)
+        cv_values = session.contentview.read(cv_name)
+        assert cv_values['yumrepo']['repos']['assigned'][0] == repo_name


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_contentview.py 
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 2 items                                                                                                                                                                            
2018-03-29 15:36:49 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentview.py ..                                                                                                                                         [100%]

================================================================================= 2 passed in 495.50 seconds ===========================
```